### PR TITLE
replaced invalid character in policy name

### DIFF
--- a/templates/enroll_tokenlabel.json
+++ b/templates/enroll_tokenlabel.json
@@ -1,4 +1,4 @@
-{"name": "enroll-tokenlabel",
+{"name": "enroll_tokenlabel",
  "description": "Set the tokenlabel of a Google Authenticator to a sensible value.",
  "scope": "enrollment",
  "action": {"tokenlabel": "<u>@<r>/<s>"}


### PR DESCRIPTION
Quote: The name of the policy may only contain the characters a-zA-Z0-9_.
