### PR TITLE
Add service id rights to superuser

### DIFF
--- a/templates/superuser.json
+++ b/templates/superuser.json
@@ -97,6 +97,13 @@
             "tokengroup_delete": true,
             "tokengroups": true,
             "tokengroup_list": true,
-            "tokengroup_add": true
+            "tokengroup_add": true,
+            "serviceid_add": true,
+            "serviceid_delete": true,
+            "serviceid_list": true,
+            "enrollAPPLSPEC": true,
+            "daypassword_force_server_generate": true,
+            "enrollDAYPASSWORD": true,
+            "setdescription": true
     }
 }


### PR DESCRIPTION
Enable enrollment of application specific password token and daypassword token.
Also enable "setdescription" rights for superuser.

Based on privacyIDEA v3.9
