### PR TITLE
Use new tags for tokenlabel

### DIFF
--- a/templates/enroll_tokenlabel.json
+++ b/templates/enroll_tokenlabel.json
@@ -1,5 +1,8 @@
-{"name": "enroll_tokenlabel",
- "description": "Set the tokenlabel of a Google Authenticator to a sensible value.",
- "scope": "enrollment",
- "action": {"tokenlabel": "<u>@<r>/<s>"}
+{
+  "name": "enroll_tokenlabel",
+  "description": "Set the tokenlabel of a Google Authenticator to a sensible value.",
+  "scope": "enrollment",
+  "action": {
+    "tokenlabel": "{user}@{realm}/{serial}"
+  }
 }


### PR DESCRIPTION
Since version 3.9 <>-style tags are [no longer](https://privacyidea.readthedocs.io/en/v3.9/policies/enrollment.html#tokenlabel) mentioned in the documentation. Tested on privacyIDEA 3.9.3.  
